### PR TITLE
Updated to work without having to launch from terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## WARNING
 
 - Only supports OS X, linux
-- You must start the `Sublime Text 2` from the terminal
+- You must start the `Sublime Text 2` from the terminal (or configure *octopress_cmd_before_rake* in your settings)
 
 ## Preview
 ![image](https://lh3.googleusercontent.com/-yFnkYy_h9bo/UHlZwhPHNKI/AAAAAAAACCE/njGTdOMnoD8/s800/Screen%2520Shot%25202012-10-13%2520at%252020.33.03.png)
@@ -21,7 +21,9 @@ Clone or copy this repository into your Packages
 ```
 {
   // path to your octopress
-  "octopress_path": "/you_octopress_path",
+  "octopress_path": "/you_octopress_path",	
+  // command to run before calling rake, eg source ~/.bash_profile to set up your local environment inc paths to ruby, rake etc.
+  "octopress_cmd_before_rake" : "source ~/.bash_profile",
   // true or false
   "use_bundle": false
 }

--- a/octopress.py
+++ b/octopress.py
@@ -30,11 +30,14 @@ class OctopressCommand(sublime_plugin.WindowCommand):
         if self.octopress_path[-1] != os.sep:
             self.octopress_path += os.sep
 
-        self.rake_command = "rake"
+        pre_rake = octo_set.get("octopress_cmd_before_rake")
+        if (pre_rake != ''):
+            pre_rake += '; ';
+        self.rake_command = pre_rake + "rake"
 
         use_bundle = octo_set.get("use_bundle")
         if use_bundle:
-            self.rake_command = "bundle exec rake"
+            self.rake_command = pre_rake + "bundle exec rake"
 
         print self.rake_command
 

--- a/octopress.sublime-settings
+++ b/octopress.sublime-settings
@@ -1,6 +1,8 @@
 {
   // path to your octopress
   "octopress_path": "/you_octopress_path",
+    // command to run before calling rake, eg source ~/.bash_profile to set up your local environment inc paths to ruby, rake etc.
+  "octopress_cmd_before_rake" : "",
   // true or false
   "use_bundle": false
 }


### PR DESCRIPTION
Hey @blueplanet,

Here's a quick fix to allow this plugin to work when launched in any way, eg dock, finder etc not just terminal.

I haven't tested this on linux but since it relies on the user configuring the commands required to set up their environment, not detecting it, it should be OK.

-Lucas.
