### PR TITLE
Bugs in searching for the errors

### DIFF
--- a/octopress.py
+++ b/octopress.py
@@ -54,15 +54,32 @@ class OctopressCommand(sublime_plugin.WindowCommand):
     def finish(self):
         finded = re.search(self.check_str, self.output)
 
-        if finded:
-            sublime.status_message("octopress exec successfully finished.")
-
-            if self.file:
-                print "Open File : " + self.file
-                self.window.open_file(self.octopress_path + self.file)
+        if self.DoubleSearch == 1:
+            finded2 = re.search(self.check_str2, self.output)  
+            if finded and finded2:
+                sublime.status_message("octopress exec successfully finished.\n\nGenerated and deployed without errors.")
+            else:
+                sublime.status_message("")
+                sublime.error_message("Octopress exec failed. Please check octopress env, and try again.\n\nYou can check exec log in sublime console.") 
+        elif self.DoubleSearch == 2:
+            finded2 = re.search(self.check_str2, self.output) 
+            if finded:
+                sublime.status_message("octopress exec successfully finished.\n\nDeployed without any errors.")
+            elif finded2:
+                sublime.status_message("octopress exec successfully finished.\n\nEverything is up-to-date.")
+            else:
+                sublime.status_message("")
+                sublime.error_message("Octopress exec failed. Please check octopress env, and try again.\n\nYou can check exec log in sublime console.")
         else:
-            sublime.status_message("")
-            sublime.error_message("Octopress exec failed. Please check octopress env, and try again.\n\nYou can check exec log in sublime console.")
+            if finded:
+                sublime.status_message("octopress exec successfully finished.")
+
+                if self.file:
+                    print "Open File : " + self.file
+                    self.window.open_file(self.octopress_path + self.file)
+            else:
+                sublime.status_message("")
+                sublime.error_message("Octopress exec failed. Please check octopress env, and try again.\n\nYou can check exec log in sublime console.")
 
     def read_stdout(self):
         while True:
@@ -95,6 +112,7 @@ class OctopressNewPostCommand(OctopressCommand):
         command = " \"new_post[%s]\"" % text
 
         self.check_str = "Creating new post: "
+        self.DoubleSearch = 0
         self.do_open_file = True
         self.exec_command(command)
 
@@ -107,6 +125,7 @@ class OctopressNewPageCommand(OctopressCommand):
         command = " \"new_page[%s]\"" % text
 
         self.check_str = "Creating new page: "
+        self.DoubleSearch = 0
         self.do_open_file = True
         self.exec_command(command)
 
@@ -115,6 +134,7 @@ class OctopressGenerateCommand(OctopressCommand):
     def run(self):
         self.file = ""
         self.check_str = "Successfully generated site:"
+        self.DoubleSearch = 0
         self.do_open_file = False
         self.exec_command("generate")
 
@@ -122,7 +142,9 @@ class OctopressGenerateCommand(OctopressCommand):
 class OctopressDeployCommand(OctopressCommand):
     def run(self):
         self.file = ""
-        self.check_str = "(## Github Pages deploy complete|OK)"
+        self.check_str = "To"
+        self.check_str2 = "Everything up-to-date"
+        self.DoubleSearch = 2
         self.do_open_file = False
         self.exec_command("deploy")
 
@@ -130,7 +152,9 @@ class OctopressDeployCommand(OctopressCommand):
 class OctopressGenerateAndDeployCommand(OctopressCommand):
     def run(self):
         self.file = ""
-        self.check_str = "(## Github Pages deploy complete|OK)"
+        self.DoubleSearch = 1
+        self.check_str = "To"
+        self.check_str2 = "Successfully generated site:"
         self.do_open_file = False
         self.exec_command("gen_deploy")
 


### PR DESCRIPTION
I found two bugs:
1) If you do "Generate and deploy" and if there are some errors in
generate stage, plugin doesn't show any errors, just deploys and sais
that everything is OK. 
For example:

```
octopress exec start.
source ~/.bashrc && export LANG=en_US.UTF-8 && export LC_ALL=en_US.UTF-8; rake
## Generating Site with Jekyll

[33munchanged[0m sass/screen.scss

/Users/goooseman/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/pygments.rb-0.3.4/lib/pygments/popen.rb:377:in `header_to_json': Traceback (most recent call last): (MentosError)
  File "/Users/goooseman/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/pygments.rb-0.3.4/lib/pygments/mentos.py", line 303, in start
    res = self.get_data(method, lexer, args, kwargs, text)
  File "/Users/goooseman/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/pygments.rb-0.3.4/lib/pygments/mentos.py", line 171, in get_data
    res = self.highlight_text(text, lexer, formatter_name, args, _convert_keys(opts))
  File "/Users/goooseman/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/pygments.rb-0.3.4/lib/pygments/mentos.py", line 122, in highlight_text
    lexer = self.return_lexer(lexer, args, kwargs, code)
  File "/Users/goooseman/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/pygments.rb-0.3.4/lib/pygments/mentos.py", line 79, in return_lexer
    return lexers.get_lexer_by_name(lexer, **inputs)
  File "/Users/goooseman/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/pygments.rb-0.3.4/vendor/pygments-main/pygments/lexers/__init__.py", line 80, in get_lexer_by_name
    raise ClassNotFound('no lexer for alias %r found' % _alias)
ClassNotFound: no lexer for alias 'PATH=$PATH:$HOME/.rvm/bin' found

    from /Users/goooseman/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/pygments.rb-0.3.4/lib/pygments/popen.rb:260:in `handle_header_and_return'
    from /Users/goooseman/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/pygments.rb-0.3.4/lib/pygments/popen.rb:235:in `block in mentos'
    from /Users/goooseman/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/timeout.rb:68:in `timeout'
    from /Users/goooseman/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/pygments.rb-0.3.4/lib/pygments/popen.rb:206:in `mentos'
    from /Users/goooseman/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/pygments.rb-0.3.4/lib/pygments/popen.rb:189:in `highlight'
    from /Volumes/DATA/Users/goooseman/octopress/plugins/pygments_code.rb:24:in `pygments'
    from /Volumes/DATA/Users/goooseman/octopress/plugins/pygments_code.rb:14:in `highlight'
    from /Volumes/DATA/Users/goooseman/octopress/plugins/backtick_code_block.rb:37:in `block in render_code_block'
    from /Volumes/DATA/Users/goooseman/octopress/plugins/backtick_code_block.rb:13:in `gsub'
    from /Volumes/DATA/Users/goooseman/octopress/plugins/backtick_code_block.rb:13:in `render_code_block'
    from /Volumes/DATA/Users/goooseman/octopress/plugins/octopress_filters.rb:12:in `pre_filter'
    from /Volumes/DATA/Users/goooseman/octopress/plugins/octopress_filters.rb:28:in `pre_render'
    from /Volumes/DATA/Users/goooseman/octopress/plugins/post_filters.rb:112:in `block in pre_render'
    from /Volumes/DATA/Users/goooseman/octopress/plugins/post_filters.rb:111:in `each'
    from /Volumes/DATA/Users/goooseman/octopress/plugins/post_filters.rb:111:in `pre_render'
    from /Volumes/DATA/Users/goooseman/octopress/plugins/post_filters.rb:166:in `do_layout'
    from /Users/goooseman/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/jekyll-0.12.0/lib/jekyll/post.rb:195:in `render'
    from /Users/goooseman/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/jekyll-0.12.0/lib/jekyll/site.rb:200:in `block in render'
    from /Users/goooseman/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/jekyll-0.12.0/lib/jekyll/site.rb:199:in `each'
    from /Users/goooseman/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/jekyll-0.12.0/lib/jekyll/site.rb:199:in `render'
    from /Users/goooseman/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/jekyll-0.12.0/lib/jekyll/site.rb:41:in `process'
    from /Users/goooseman/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/jekyll-0.12.0/bin/jekyll:264:in `<top (required)>'
    from /Users/goooseman/.rbenv/versions/1.9.3-p194/bin/jekyll:23:in `load'
    from /Users/goooseman/.rbenv/versions/1.9.3-p194/bin/jekyll:23:in `<main>'

Configuration from /Volumes/DATA/Users/goooseman/octopress/_config.yml
Building site: source -> public

rm -rf _deploy/2013


rm -rf _deploy/about


rm -rf _deploy/archives


rm -rf _deploy/atom.xml


rm -rf _deploy/categories


rm -rf _deploy/category-list


rm -rf _deploy/CNAME


rm -rf _deploy/favicon.png


rm -rf _deploy/font


rm -rf _deploy/images


rm -rf _deploy/index.html


rm -rf _deploy/javascripts


rm -rf _deploy/search.html


rm -rf _deploy/sitemap.xml


rm -rf _deploy/stylesheets


cp -r public/. _deploy


cd _deploy


## Deploying branch to Github Pages 

## copying public to _deploy


## Commiting: Site updated at 2013-03-07 13:56:23 UTC

[master a545d7a] Site updated at 2013-03-07 13:56:23 UTC
 10 files changed, 10 insertions(+), 10 deletions(-)


## Pushing generated _deploy website

To git@github.com:goooseman/goooseman.github.com.git

   7b3a48d..a545d7a  
master -> master


cd -


## Github Pages deploy complete

octopress exec end.
```

2) If you do "Deploy" or "Generate and Deploy" and there are some
errors in deploying stage (for example no internet connection), plugin
still shows "octopress exec end." and no errors. This is because it
searches for the "## Github Pages deploy complete", but this string
appears even if there are some problems in deploying. For example:

```
## Commiting: Site updated at 2013-03-07 14:14:10 UTC

[master b20343e] Site updated at 2013-03-07 14:14:10 UTC
 12 files changed, 247 insertions(+), 160 deletions(-)

## Pushing generated _deploy website

ssh: Could not resolve hostname github.com: nodename nor servname
provided, or not known

fatal: The remote end hung up unexpectedly

cd -

## Github Pages deploy complete
octopress exec end.
```

So I figured out with two this bugs.
I have tested it for a while about different errors in generating or deploying stage, now everything is OK.
